### PR TITLE
Use YYYY-MM-DD instead of YYYY/MM/DD on the blog 

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -16,7 +16,7 @@
     <article class="archive-item">
       <a href="{{ .RelPermalink }}" class="archive-item-link">{{ .Title }}</a>
       <span class="archive-item-date">
-        {{ .Date.Format "2006/01/02" }}
+        {{ .Date.Format "2006-01-02" }}
       </span>
     </article>
     {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,7 @@
     <h1 class="article-title">{{ .Title }}</h1>
 
     {{ if eq .Section "post" }}
-    <span class="article-date">{{ .Date.Format "2006/01/02" }}</span>
+    <span class="article-date">{{ .Date.Format "2006-01-02" }}</span>
     {{ end }}
 
     <div class="article-content">


### PR DESCRIPTION
Hi, it's great that you use a year-month-day order for your dates in your blogs.
However, you should use a `-` instead of the `/` for separating the fields. This would be in accordance with the international ISO8601 format and would make it easier to read as the `/` is normally associated with a MM/DD/YYYY order.
Sorry for the minor request, but this is a true pet peeve of mine 😅.