### PR TITLE
solve responsite problem for images

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -29,6 +29,11 @@ code {
   background-color: rgba(0, 0, 0, 0.02);
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 .wrapper {
   overflow: hidden;
   position: relative;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -31,7 +31,6 @@ code {
 
 img {
   max-width: 100%;
-  height: auto;
 }
 
 .wrapper {


### PR DESCRIPTION
When we add an image in posts in blogdown like R plots, on smartphones plot is really big and don't see in the screen.