### PR TITLE
Add unsafe = true to config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -40,3 +40,7 @@ ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_cache$", "\\.knit\\.md$", "\\.utf8\
     height = 50
     alt = "Logo"
 
+[markup]
+  defaultMarkdownHandler = "goldmark"
+  [markup.goldmark.renderer]
+    unsafe = true  # Enable user to embed HTML snippets in Markdown content.


### PR DESCRIPTION
Hi @yihui - working on blogdown "get started" with the default theme, and here is the output from the checking function:

```
> blogdown::check_config()
― Checking config.yaml
| Checking "baseURL" setting for Hugo...
● [TODO] Update "baseURL" to your actual URL when ready to publish.
| Checking "ignoreFiles" setting for Hugo...
○ "ignoreFiles" looks good - nothing to do here!
| Checking setting for Hugo's Markdown renderer...
| You are using the Markdown renderer 'goldmark'.
● [TODO] Allow goldmark to render raw HTML by adding this setting to config.yaml (see https://github.com/rstudio/blogdown/issues/447 for more info):

markup:
  goldmark:
    renderer:
      unsafe: true

► Do you want blogdown to set this for you? (y/n) 
```